### PR TITLE
Add UnmarshalJSONRequest

### DIFF
--- a/json.go
+++ b/json.go
@@ -146,6 +146,14 @@ func respond(w http.ResponseWriter, req *http.Request, res JSONResponse) {
 	w.Write(resBytes)
 }
 
+// UnmarshalJSONRequest into the given interface. Returns an error if failed to unmarshal. Calling
+// this function will consume the request body and close it.
+func UnmarshalJSONRequest(req *http.Request, iface interface{}) (err error) {
+	defer req.Body.Close()
+	err = json.NewDecoder(req.Body).Decode(iface)
+	return
+}
+
 // WithCORSOptions intercepts all OPTIONS requests and responds with CORS headers. The request handler
 // is not invoked when this happens.
 func WithCORSOptions(handler http.HandlerFunc) http.HandlerFunc {

--- a/json_test.go
+++ b/json_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -20,6 +21,18 @@ func (h *MockJSONRequestHandler) OnIncomingRequest(req *http.Request) JSONRespon
 
 type MockResponse struct {
 	Foo string `json:"foo"`
+}
+
+func TestUnmarshalJSONRequest(t *testing.T) {
+	req := httptest.NewRequest("PUT", "http://localhost", bytes.NewBufferString(`{"foo":"hello"}`))
+	var i MockResponse
+	if err := UnmarshalJSONRequest(req, &i); err != nil {
+		t.Fatalf("TestUnmarshalJSONRequest expect no error, got %s", err)
+	}
+	want := "hello"
+	if i.Foo != want {
+		t.Fatalf("TestUnmarshalJSONRequest wanted %s, got %s", want, i.Foo)
+	}
 }
 
 func TestMakeJSONAPI(t *testing.T) {

--- a/json_test.go
+++ b/json_test.go
@@ -33,6 +33,12 @@ func TestUnmarshalJSONRequest(t *testing.T) {
 	if i.Foo != want {
 		t.Fatalf("TestUnmarshalJSONRequest wanted %s, got %s", want, i.Foo)
 	}
+
+	// test error case
+	req = httptest.NewRequest("PUT", "http://localhost", bytes.NewBufferString(`{"foo":"incomplete_json"`))
+	if err := UnmarshalJSONRequest(req, &i); err == nil {
+		t.Fatalf("TestUnmarshalJSONRequest wanted error, got nil")
+	}
 }
 
 func TestMakeJSONAPI(t *testing.T) {


### PR DESCRIPTION
This is mainly so we cannot forget to call `Close()` on the request (and therefore leak memory/goroutines like we've done in the past). Usage is also a bit shorter:
```go
func foo(req *http.Request) {
    var s SomeStruct
    if err := util.UnmarshalJSONRequest(req, &s); err != nil {
        return err
    }
}
```
vs
```go
func foo(req *http.Request) {
    defer req.Body.Close()
    var s SomeStruct
    if err := json.NewDecoder(req.Body).Decode(&s); err != nil {
        return err
    }
}
```