### PR TITLE
Separate pre-commit hook and CI script

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
   - command:
       - "go get golang.org/x/lint/golint"
       - "go get github.com/fzipp/gocyclo"
-      - "./hooks/pre-commit"
+      - "./scripts/lint.sh"
     label: "\U0001F9F9 Run tests and linting"
     plugins:
       - docker#v3.0.1:

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,6 +4,6 @@ set -eu
 
 golint
 go fmt
-go vet --all .
+go vet .
 gocyclo -over 12 .
 go test -timeout 5s -test.v

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+set -eu
+
+golint --set_exit_status
+gofmt -d .
+go vet -c=5
+gocyclo -over 12 .
+go test -timeout 5s -test.v

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-golint --set_exit_status
+golint -set_exit_status
 gofmt -d .
 go vet -c=5
 gocyclo -over 12 .


### PR DESCRIPTION
The `pre-commit` hook that was running in CI before would just correct mistakes instead of actually checking them and failing if so. So yes, this is what a pre-commit hook should do, but not CI.

Add a separate script for CI so we have more flexibility.